### PR TITLE
Llf language codes

### DIFF
--- a/lgg/0364_jo-yi-enyumba.md
+++ b/lgg/0364_jo-yi-enyumba.md
@@ -58,4 +58,4 @@ yiino!
 * Text: Clare Verbeek, Thembani Dladla, Zanele Buthelezi
 * Illustration: Kathy Arbuckle
 * Adaptation: Candiru Eunice
-* Language: lgg, Lunyole
+* Language: lgg

--- a/st/0338_mokopu-oa-me-maneo.md
+++ b/st/0338_mokopu-oa-me-maneo.md
@@ -123,4 +123,4 @@ Baea ho 'M'e Maneo. Bare,
 * License: [CC-BY]
 * Text: Marion Drew
 * Illustration: Marion Drew
-* Language: st (Lesotho)
+* Language: st


### PR DESCRIPTION
A few of the stories have language metadata consisting of something other than their language code. 
* st (Lesotho) -> st
* lgg, Lunyoye -> lgg (the nyole version seems to be in the nuj diretory already

The only thing left is Aringati, but there doesn't seem to be a language code for that!
